### PR TITLE
feat: add clickable URLs in task descriptions with live preview strip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,73 @@ This file provides guidance to AI LLM Agents like Claude Code (claude.ai/code), 
 
 Kanvana a local-first personal + AI Agent kanban board with no backend. `docs/specification-kanban.md` is the specification index and governance entrypoint, and `docs/spec/` contains the canonical feature and data specifications. All state lives in browser localStorage. Built with vanilla JavaScript, HTML, and CSS using Vite for bundling.
 
+## Purpose
+
+Kanvana is a process workflow optimized kanban board system for one person plus their AI-agent run company or companies. The current implementation target is V2 and is defined in docs/spec/specification-kanban.md.
+
+## Read This First
+
+Before making changes, read in this order:
+
+The specification files include core data structures and feature behavior that must be maintained at all times.
+
+- `docs/specification-kanban.md` - Specification index, update policy, and code-to-spec ownership map.
+- `docs/spec/*.md` - Canonical feature, data, storage, workflow, and testing specifications.
+- docs/spec/specification-kanban.md
+
+## Repo Map
+
+TODO
+
+
+## Core Engineering Rules
+
+1. Keep changes company-scoped. Every domain entity should be scoped to a company and company boundaries must be enforced in routes/services.
+
+2. Keep contracts synchronized. If you change schema/API behavior, update all impacted layers:
+
+  - packages/db schema and exports
+  - packages/shared types/constants/validators
+  - server routes/services
+  - ui API clients and pages
+3.  Preserve control-plane invariants.
+- Single-assignee task model
+- Atomic issue checkout semantics
+- Approval gates for governed actions
+- Budget hard-stop auto-pause behavior
+- Activity logging for mutating actions
+4. Do not replace strategic docs wholesale unless asked. Prefer additive updates. Keep doc/SPEC.md and doc/SPEC-implementation.md aligned.
+5.  Keep plan docs dated and centralized. New plan documents belong in doc/plans/ and should use YYYY-MM-DD-slug.md filenames.
+
+## Database Change Workflow
+
+TODO
+
+##  Verification Before Hand-off
+
+TODO
+
+## API and Auth Expectations
+
+TODO
+
+## UI Expectations
+
+- Keep routes and nav aligned with available API surface
+- Use company selection context for company-scoped pages
+- Surface failures clearly; do not silently ignore API errors
+
+
+## Definition of Done
+
+A change is done when all are true:
+
+- Behavior matches docs/SPEC-implementation.md
+- Typecheck, tests, and build pass
+- Contracts are synced across
+- Docs, Specs and Changelog updated when behavior or commands change
+
+
 ## Commands
 
 ```bash
@@ -19,13 +86,6 @@ npm run test:e2e   # Run Playwright end-to-end tests (tests/e2e)
 npm run test:ui    # Run Playwright tests with interactive UI
 npm run test:debug # Run Playwright tests in debug mode
 ```
-
-## Specification
-
-The specification files include core data structures and feature behavior that must be maintained at all times.
-
-- `docs/specification-kanban.md` - Specification index, update policy, and code-to-spec ownership map.
-- `docs/spec/*.md` - Canonical feature, data, storage, workflow, and testing specifications.
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- URLs in task descriptions are automatically rendered as clickable links on task cards — links open in a new tab and do not trigger the edit modal. Only `http://` and `https://` URLs are linkified; rendering uses DOM APIs (no innerHTML) for XSS safety.
+- Live link preview strip in the task modal: when a `http://` or `https://` URL is present in the description field, clickable chips appear below the textarea in real time — no need to save first. Duplicate URLs are deduplicated. The strip hides itself when no URLs are present.
 
 ## [1.5.0] - 2026-04-03
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Configure swim lanes in **Settings** or use the quick-access toggle in the board
 
 ### Core Features
 
+- **🔗 Clickable URLs in Descriptions**: Paste any `http://` or `https://` link into a task description and it becomes a clickable link on the card — opens in a new tab, no page refresh. A live link preview strip also appears below the description field in the task modal as you type, so you can click URLs without saving first
 - **🚀 Blazing Fast & Simple**: Lightning-quick performance with a clean, intuitive interface
 - **🔍 Powerful Search**: Find tasks instantly by label, title, description, or label groups
 - **📊 Productivity Reports**: Visualize your progress with Cumulative Flow Diagrams, weekly lead time, completion stats, same-day completions tracking, and an activity heatmap covering the last 365 days

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -22,6 +22,8 @@
 - Drag-and-drop is distinguished from clicks by pointer movement threshold
 - Titles are clamped to one line and descriptions to a short preview
 - Footer content is controlled by settings and can include change date, due date, countdown, and task age
+- URLs (`http://` or `https://`) in the description are rendered as clickable `<a>` links that open in a new tab (`target="_blank" rel="noopener noreferrer"`); clicking a link does not open the edit modal. Plain-text editing in the modal is unchanged — linkification is display-only on the card.
+- In the task modal (add and edit), a live link preview strip appears below the description textarea whenever one or more `http://`/`https://` URLs are detected. Each unique URL renders as a clickable chip that opens in a new tab. The strip updates on every keystroke/paste and hides itself when no URLs are present. Existing URLs are shown immediately when the edit modal opens.
 
 ## Due Dates and Age
 

--- a/src/index.html
+++ b/src/index.html
@@ -142,6 +142,7 @@
             <div class="form-group">
               <label for="task-description">Description</label>
               <textarea id="task-description" rows="3" placeholder="Enter task description..."></textarea>
+              <div id="task-description-links" class="description-links" hidden aria-label="Links in description"></div>
             </div>
             <div class="form-group">
               <label for="task-priority">Priority</label>

--- a/src/modules/task-card.js
+++ b/src/modules/task-card.js
@@ -59,6 +59,35 @@ function formatTaskAge(task) {
 
 export { formatDisplayDate, formatDisplayDateTime };
 
+// Safely convert URLs in text to <a> elements. Returns a DocumentFragment.
+// Only http/https URLs are matched; DOM APIs prevent XSS.
+export function linkifyText(text) {
+  const URL_RE = /https?:\/\/[^\s<>"']+/g;
+  const frag = document.createDocumentFragment();
+  let last = 0;
+  let match;
+  while ((match = URL_RE.exec(text)) !== null) {
+    if (match.index > last) {
+      frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+    }
+    const a = document.createElement('a');
+    a.href = match[0];
+    // Guard: only allow http/https even after DOM parsing
+    if (a.protocol !== 'https:' && a.protocol !== 'http:') {
+      frag.appendChild(document.createTextNode(match[0]));
+    } else {
+      a.textContent = match[0];
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.addEventListener('click', (e) => e.stopPropagation());
+      frag.appendChild(a);
+    }
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+  return frag;
+}
+
 // Create a task element
 export function createTaskElement(task, settings, labelsMap = null, today = null) {
   const li = document.createElement('li');
@@ -77,6 +106,8 @@ export function createTaskElement(task, settings, labelsMap = null, today = null
   li.addEventListener('click', (e) => {
     // Skip if click is on or inside the delete button
     if (e.target.closest('.delete-task-btn')) return;
+    // Skip if click is on a description link
+    if (e.target.closest('.task-description a')) return;
     // Skip if pointer moved significantly (user was dragging)
     if (pointerDownPos) {
       const dx = Math.abs(e.clientX - pointerDownPos.x);
@@ -160,8 +191,12 @@ export function createTaskElement(task, settings, labelsMap = null, today = null
   const descriptionValue = typeof task.description === 'string' ? task.description.trim() : '';
   const descriptionEl = document.createElement('div');
   descriptionEl.classList.add('task-description');
-  descriptionEl.textContent = descriptionValue;
-  descriptionEl.style.display = descriptionValue ? 'block' : 'none';
+  if (descriptionValue) {
+    descriptionEl.appendChild(linkifyText(descriptionValue));
+    descriptionEl.style.display = 'block';
+  } else {
+    descriptionEl.style.display = 'none';
+  }
 
   li.appendChild(header);
   li.appendChild(descriptionEl);

--- a/src/modules/task-modal.js
+++ b/src/modules/task-modal.js
@@ -515,6 +515,7 @@ export function showModal(columnName, swimlaneContext) {
   columnSelect.value = currentColumn;
   taskTitle.value = '';
   taskDescription.value = '';
+  updateDescriptionLinks('');
   if (taskPriority) {
     const settings = loadSettings();
     taskPriority.value = settings.defaultPriority || 'none';
@@ -584,6 +585,7 @@ export function showEditModal(taskId) {
   const legacyTitle = typeof task.text === 'string' ? task.text : '';
   taskTitle.value = (typeof task.title === 'string' && task.title.trim() !== '') ? task.title : legacyTitle;
   taskDescription.value = typeof task.description === 'string' ? task.description : '';
+  updateDescriptionLinks(taskDescription.value);
   if (taskPriority) taskPriority.value = typeof task.priority === 'string' ? task.priority : 'none';
 
   const rawDue = typeof task.dueDate === 'string' ? task.dueDate : '';
@@ -628,7 +630,33 @@ function scrollHighlightedLabelIntoView() {
   if (highlighted) highlighted.scrollIntoView({ block: 'nearest' });
 }
 
+const URL_RE = /https?:\/\/[^\s<>"']+/g;
+
+export function updateDescriptionLinks(text) {
+  const container = document.getElementById('task-description-links');
+  if (!container) return;
+  container.innerHTML = '';
+  const matches = [...(text || '').matchAll(URL_RE)].map(m => m[0]);
+  if (matches.length === 0) { container.hidden = true; return; }
+  const unique = [...new Set(matches)];
+  unique.forEach(url => {
+    const a = document.createElement('a');
+    a.href = url;
+    if (a.protocol !== 'https:' && a.protocol !== 'http:') return;
+    a.textContent = url;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.classList.add('description-link-chip');
+    container.appendChild(a);
+  });
+  container.hidden = container.childElementCount === 0;
+}
+
 export function initializeTaskModalHandlers(setupModalCloseHandlers) {
+  document.getElementById('task-description')?.addEventListener('input', (e) => {
+    updateDescriptionLinks(e.target.value);
+  });
+
   const taskLabelSearch = document.getElementById('task-label-search');
   taskLabelSearch?.addEventListener('input', () => {
     labelSearchHighlightIndex = 0;

--- a/src/styles/components/card.css
+++ b/src/styles/components/card.css
@@ -112,6 +112,16 @@
   color: var(--text-subtle);
 }
 
+.task-description a {
+  color: var(--accent, #4f8ef7);
+  text-decoration: underline;
+  word-break: break-all;
+}
+
+.task-description a:hover {
+  opacity: 0.8;
+}
+
 /* Relationship indicator row on task card */
 .task-relationships-row {
   display: flex;

--- a/src/styles/components/forms.css
+++ b/src/styles/components/forms.css
@@ -52,6 +52,34 @@ fieldset.form-group legend {
   min-height: 60px;
 }
 
+/* Live link preview strip below description textarea */
+.description-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.description-link-chip {
+  display: inline-block;
+  max-width: 100%;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--input-focus-ring, rgba(79, 142, 247, 0.12));
+  color: var(--color-primary, #4f8ef7);
+  font-size: 12px;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.description-link-chip:hover {
+  text-decoration: underline;
+  opacity: 0.85;
+}
+
 .form-group input:focus,
 .form-group textarea:focus,
 .form-group select:focus {

--- a/tests/dom/task-card-linkify.test.js
+++ b/tests/dom/task-card-linkify.test.js
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { linkifyText } from '../../src/modules/task-card.js';
+import { updateDescriptionLinks } from '../../src/modules/task-modal.js';
+
+function renderFragment(text) {
+  const div = document.createElement('div');
+  div.appendChild(linkifyText(text));
+  return div;
+}
+
+describe('linkifyText', () => {
+  test('plain text with no URL is rendered as a text node', () => {
+    const el = renderFragment('just a plain description');
+    expect(el.querySelectorAll('a')).toHaveLength(0);
+    expect(el.textContent).toBe('just a plain description');
+  });
+
+  test('https URL becomes a clickable link', () => {
+    const el = renderFragment('https://example.com');
+    const links = el.querySelectorAll('a');
+    expect(links).toHaveLength(1);
+    expect(links[0].href).toBe('https://example.com/');
+    expect(links[0].textContent).toBe('https://example.com');
+  });
+
+  test('http URL becomes a clickable link', () => {
+    const el = renderFragment('http://example.com/page');
+    const links = el.querySelectorAll('a');
+    expect(links).toHaveLength(1);
+    expect(links[0].href).toBe('http://example.com/page');
+  });
+
+  test('link opens in a new tab with noopener noreferrer', () => {
+    const el = renderFragment('see https://example.com for details');
+    const a = el.querySelector('a');
+    expect(a?.target).toBe('_blank');
+    expect(a?.rel).toBe('noopener noreferrer');
+  });
+
+  test('surrounding text is preserved around the link', () => {
+    const el = renderFragment('visit https://example.com for info');
+    expect(el.textContent).toBe('visit https://example.com for info');
+    const a = el.querySelector('a');
+    expect(a?.textContent).toBe('https://example.com');
+  });
+
+  test('multiple URLs in one description each become a link', () => {
+    const el = renderFragment('a https://foo.com and https://bar.com here');
+    const links = el.querySelectorAll('a');
+    expect(links).toHaveLength(2);
+    expect(links[0].href).toContain('foo.com');
+    expect(links[1].href).toContain('bar.com');
+  });
+
+  test('empty string returns an empty fragment', () => {
+    const el = renderFragment('');
+    expect(el.textContent).toBe('');
+    expect(el.querySelectorAll('a')).toHaveLength(0);
+  });
+
+  test('non-http scheme is not linkified', () => {
+    const el = renderFragment('ftp://example.com');
+    expect(el.querySelectorAll('a')).toHaveLength(0);
+    expect(el.textContent).toBe('ftp://example.com');
+  });
+});
+
+describe('updateDescriptionLinks (modal preview strip)', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'task-description-links';
+    container.hidden = true;
+    document.body.appendChild(container);
+  });
+
+  test('hidden when text has no URLs', () => {
+    updateDescriptionLinks('just some notes');
+    expect(container.hidden).toBe(true);
+    expect(container.querySelectorAll('a')).toHaveLength(0);
+  });
+
+  test('shows a chip for a single URL', () => {
+    updateDescriptionLinks('see https://example.com');
+    expect(container.hidden).toBe(false);
+    const chips = container.querySelectorAll('a.description-link-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].href).toContain('example.com');
+    expect(chips[0].target).toBe('_blank');
+    expect(chips[0].rel).toBe('noopener noreferrer');
+  });
+
+  test('deduplicates the same URL appearing twice', () => {
+    updateDescriptionLinks('https://example.com and https://example.com again');
+    const chips = container.querySelectorAll('a.description-link-chip');
+    expect(chips).toHaveLength(1);
+  });
+
+  test('shows one chip per distinct URL', () => {
+    updateDescriptionLinks('https://foo.com and https://bar.com');
+    const chips = container.querySelectorAll('a.description-link-chip');
+    expect(chips).toHaveLength(2);
+  });
+
+  test('hides and clears when called with empty string', () => {
+    updateDescriptionLinks('https://example.com');
+    expect(container.hidden).toBe(false);
+    updateDescriptionLinks('');
+    expect(container.hidden).toBe(true);
+    expect(container.querySelectorAll('a')).toHaveLength(0);
+  });
+
+  test('non-http scheme does not produce a chip', () => {
+    updateDescriptionLinks('ftp://example.com');
+    expect(container.hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- URLs in task descriptions are automatically rendered as clickable links on task cards — links open in a new tab and do not trigger the edit modal. Only `http://` and `https://` URLs are linkified; rendering uses DOM APIs (no innerHTML) for XSS safety.
- Live link preview strip in the task modal: when a `http://` or `https://` URL is present in the description field, clickable chips appear below the textarea in real time — no need to save first. Duplicate URLs are deduplicated. The strip hides itself when no URLs are present.
