### PR TITLE
Fix visibility of delete icon for long title sub-tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URLs in task descriptions are automatically rendered as clickable links on task cards — links open in a new tab and do not trigger the edit modal. Only `http://` and `https://` URLs are linkified; rendering uses DOM APIs (no innerHTML) for XSS safety.
 - Live link preview strip in the task modal: when a `http://` or `https://` URL is present in the description field, clickable chips appear below the textarea in real time — no need to save first. Duplicate URLs are deduplicated. The strip hides itself when no URLs are present.
 
+### Fixed
+
+- Sub-task delete button (×) is no longer pushed off-screen when the sub-task title is long; the title now truncates with an ellipsis so the delete button always remains visible.
+
 ## [1.5.0] - 2026-04-03
 
 ### Added

--- a/docs/spec/sub-tasks.md
+++ b/docs/spec/sub-tasks.md
@@ -24,7 +24,8 @@ Sub-tasks do not support labels, relationships, priorities, due dates, or column
 - Each sub-task title can be edited inline by clicking it; an input field appears in place of the title
   - Press **Enter** or blur to commit; press **Escape** to cancel and restore the original title
   - Committing an empty string is a no-op (original title is preserved)
-- Each sub-task has a delete button that removes it from the list immediately
+- Each sub-task has a delete button (× icon) on the far right that removes it from the list immediately — no confirmation dialog is shown
+- Long sub-task titles are truncated with an ellipsis so the delete button always remains visible
 
 ## Ordering
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2503,9 +2503,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/styles/components/forms.css
+++ b/src/styles/components/forms.css
@@ -7,6 +7,7 @@ fieldset.form-group {
   border: none;
   padding: 0;
   margin: 0 0 16px 0;
+  min-width: 0;
 }
 
 fieldset.form-group legend {

--- a/src/styles/components/labels.css
+++ b/src/styles/components/labels.css
@@ -496,6 +496,8 @@
   padding: 4px 6px;
   border-radius: 4px;
   background: var(--color-bg-secondary, #f8fafc);
+  min-width: 0;
+  overflow: hidden;
 }
 
 .subtask-drag-handle {
@@ -517,6 +519,7 @@
 
 .subtask-title {
   flex: 1;
+  min-width: 0;
   font-size: 0.875rem;
   cursor: pointer;
   overflow: hidden;


### PR DESCRIPTION
This pull request addresses a UI issue where long sub-task titles could push the delete (×) button off-screen, making it inaccessible. The changes ensure that sub-task titles are truncated with an ellipsis so that the delete button always remains visible. Documentation and styles have been updated to reflect and support this behavior.

**Bug Fixes and UI Improvements:**
* Sub-task delete button (×) now remains visible even when the sub-task title is long; titles are truncated with an ellipsis to prevent overflow.

**Documentation Updates:**
* Updated the sub-task spec to clarify that the delete button is always visible on the far right and that long titles are truncated with an ellipsis.

**CSS and Styling Adjustments:**
* Added `min-width: 0` to `.form-group` fieldsets to support flexbox truncation and prevent overflow.
* Updated `.subtask-label` and `.subtask-title` to include `min-width: 0` and `overflow: hidden`, ensuring proper text truncation and button visibility. [[1]](diffhunk://#diff-89038351bb3a87fbd540b1264e3d48472aec8a985cc57897db50e011885e4f95R499-R500) [[2]](diffhunk://#diff-89038351bb3a87fbd540b1264e3d48472aec8a985cc57897db50e011885e4f95R522)
