### PR TITLE
Enhance keyboard navigation and update changelog for version 1.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         working-directory: client
       - run: npm run build
         working-directory: client
+        env:
+          VITE_PB_URL: ${{ secrets.VITE_PB_URL }}
 
       - name: Verify build output
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+
+## [1.7.1] - 2026-05-14
+
+### Added
+
 - Quick board switch: clicking the board name in the header (`#brand-text`) opens the Manage Boards modal
 - `Ctrl+B` global keyboard shortcut opens the Manage Boards modal (ignored when an input/textarea/select is focused)
 - Arrow key navigation (`ArrowDown`/`ArrowUp`) cycles through board items in the open Manage Boards modal; `Enter` activates the highlighted board and closes the modal
@@ -40,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `autosync.js` — per-board debounced auto-sync: `scheduleAutoSync(boardId)` debounces 700ms per board, per-board in-flight guard with queue, `kanban-local-change` listener scoped to boardId, `initializeAutoSync()` registers listener + catch-up push on page load, `isAutoSyncEnabled/enableAutoSync/disableAutoSync` feature flag; replaces global single-timer approach with per-board Map state
 - `npm run test:overview` generates `tests/TEST-OVERVIEW.md`, an AI-readable inventory of test files, test cases, source plan links, and heuristic coverage gaps
 
-### Fixed
+### Changed
 
 - chore: update version in README and enhance audit trail documentation fixed drift in spec
 - `docker-compose.yml`: PocketBase service now builds from `devops/local/backend/Dockerfile`, port corrected to `8090`, healthcheck fixed to `http://localhost:8090/api/health`, data volume path corrected to `/pocketbase/data`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add secret with production pocketbase url  VITE_PB_URL: ${{ secrets.VITE_PB_URL }}
+
 ## [1.7.0] - 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Quick board switch: clicking the board name in the header (`#brand-text`) opens the Manage Boards modal
+- `Shift+B` global keyboard shortcut opens the Manage Boards modal (ignored when an input/textarea/select is focused)
+- Arrow key navigation (`ArrowDown`/`ArrowUp`) cycles through board items in the open Manage Boards modal; `Enter` activates the highlighted board and closes the modal
+- `showBoardsModal` exported from `boards-modal.js` and re-exported via `modals.js`
+
 ### Fixed
 
 - Add secret with production pocketbase url  VITE_PB_URL: ${{ secrets.VITE_PB_URL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Quick board switch: clicking the board name in the header (`#brand-text`) opens the Manage Boards modal
-- `Shift+B` global keyboard shortcut opens the Manage Boards modal (ignored when an input/textarea/select is focused)
+- `Ctrl+B` global keyboard shortcut opens the Manage Boards modal (ignored when an input/textarea/select is focused)
 - Arrow key navigation (`ArrowDown`/`ArrowUp`) cycles through board items in the open Manage Boards modal; `Enter` activates the highlighted board and closes the modal
 - `showBoardsModal` exported from `boards-modal.js` and re-exported via `modals.js`
+- User-facing keyboard shortcut documentation with a complete shortcut table in `docs/user/keybindings.md`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Track every change on your board with a built-in two-log audit system:
 ### Core Features
 
 - **🔗 Clickable URLs in Descriptions**: Paste any `http://` or `https://` link into a task description and it becomes a clickable link on the card — opens in a new tab, no page refresh. A live link preview strip also appears below the description field in the task modal as you type, so you can click URLs without saving first
+- **⌨️ Keyboard Shortcuts**: Move quickly through board management and task editing with context-aware keybindings. `Ctrl+B` opens Manage Boards, `Escape` closes active modals and menus, arrow keys navigate board and label lists, and `Enter` activates focused choices. Shortcuts are form-safe, so typing in inputs does not accidentally trigger global actions. See the full [keyboard shortcuts table](docs/user/keybindings.md).
 - **🚀 Blazing Fast & Simple**: Lightning-quick performance with a clean, intuitive interface
 - **🔍 Powerful Search**: Find tasks instantly by label, title, description, or label groups
 - **📊 Productivity Reports**: Visualize your progress with Cumulative Flow Diagrams, weekly lead time, completion stats, same-day completions tracking, and an activity heatmap covering the last 365 days

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -19,7 +19,7 @@
     <nav class="controls" role="toolbar" aria-label="Board controls">
       <div class="brand">
         <img src="./images/kanvana-logo-color-32x23.svg" alt="Kanvana" class="brand-icon brand-logo">
-        <span id="brand-text" class="brand-text">Kanvana Personal + AI-Agent Kanban</span>
+        <span id="brand-text" class="brand-text" role="button" tabindex="0" title="Manage boards (Shift+B)">Kanvana Personal + AI-Agent Kanban</span>
       </div>
 
       <div class="board-search" role="search" aria-label="Filter tasks">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -19,7 +19,7 @@
     <nav class="controls" role="toolbar" aria-label="Board controls">
       <div class="brand">
         <img src="./images/kanvana-logo-color-32x23.svg" alt="Kanvana" class="brand-icon brand-logo">
-        <span id="brand-text" class="brand-text" role="button" tabindex="0" title="Manage boards (Shift+B)">Kanvana Personal + AI-Agent Kanban</span>
+        <span id="brand-text" class="brand-text" role="button" tabindex="0" title="Manage boards (Ctrl+B)">Kanvana Personal + AI-Agent Kanban</span>
       </div>
 
       <div class="board-search" role="search" aria-label="Filter tasks">

--- a/client/src/modules/boards-modal.js
+++ b/client/src/modules/boards-modal.js
@@ -13,6 +13,7 @@ import { confirmDialog, alertDialog } from './dialog.js';
 import { renderIcons } from './icons.js';
 import { exportBoard } from './importexport.js';
 import { emit, DATA_CHANGED } from './events.js';
+import { DEFAULT_APP_KEYBINDINGS, matchesKey } from './constants.js';
 
 let editingBoardId = null;
 let keyboardNavIndex = -1;
@@ -204,9 +205,9 @@ export function initializeBoardsModalHandlers(setupModalCloseHandlers) {
     }
   });
 
-  // Shift+B global shortcut — ignored when typing in form elements.
+  // Global boards shortcut — ignored when typing in form elements.
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'B' && e.shiftKey) {
+    if (matchesKey(e, DEFAULT_APP_KEYBINDINGS.openBoardsModal)) {
       const tag = document.activeElement?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       e.preventDefault();

--- a/client/src/modules/boards-modal.js
+++ b/client/src/modules/boards-modal.js
@@ -15,6 +15,7 @@ import { exportBoard } from './importexport.js';
 import { emit, DATA_CHANGED } from './events.js';
 
 let editingBoardId = null;
+let keyboardNavIndex = -1;
 
 function renderBoardsSelect() {
   const selectEl = document.getElementById('board-select');
@@ -140,15 +141,24 @@ function renderBoardsList() {
   renderIcons();
 }
 
-function showBoardsModal() {
+export function showBoardsModal() {
+  keyboardNavIndex = -1;
   renderBoardsList();
   const modal = document.getElementById('boards-modal');
   modal?.classList.remove('hidden');
 }
 
 function hideBoardsModal() {
+  keyboardNavIndex = -1;
   const modal = document.getElementById('boards-modal');
   modal?.classList.add('hidden');
+}
+
+function updateBoardKeyboardFocus(items) {
+  items.forEach((item, i) => {
+    item.classList.toggle('keyboard-focused', i === keyboardNavIndex);
+  });
+  items[keyboardNavIndex]?.scrollIntoView?.({ block: 'nearest' });
 }
 
 export function refreshBoardsModalList() {
@@ -185,6 +195,56 @@ function hideBoardRenameModal() {
 export function initializeBoardsModalHandlers(setupModalCloseHandlers) {
   document.addEventListener('kanban:boards-changed', () => {
     refreshBoardsModalList();
+  });
+
+  // Event delegation: brand-text click survives DOM resets.
+  document.addEventListener('click', (e) => {
+    if (e.target?.id === 'brand-text' || e.target?.closest?.('#brand-text')) {
+      showBoardsModal();
+    }
+  });
+
+  // Shift+B global shortcut — ignored when typing in form elements.
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'B' && e.shiftKey) {
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      e.preventDefault();
+      showBoardsModal();
+    }
+  });
+
+  // Arrow key navigation + Enter to activate board when modal is open.
+  document.addEventListener('keydown', (e) => {
+    const modal = document.getElementById('boards-modal');
+    if (!modal || modal.classList.contains('hidden')) return;
+    const renameModal = document.getElementById('board-rename-modal');
+    if (renameModal && !renameModal.classList.contains('hidden')) return;
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Enter') return;
+
+    const items = Array.from(document.querySelectorAll('#boards-list .label-item'));
+    if (!items.length) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      keyboardNavIndex = Math.min(keyboardNavIndex + 1, items.length - 1);
+      updateBoardKeyboardFocus(items);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      keyboardNavIndex = Math.max(keyboardNavIndex - 1, 0);
+      updateBoardKeyboardFocus(items);
+    } else if (e.key === 'Enter' && keyboardNavIndex >= 0) {
+      e.preventDefault();
+      const boards = listBoards();
+      const board = boards[keyboardNavIndex];
+      if (board) {
+        setActiveBoardId(board.id);
+        renderBoardsSelect();
+        renderBoardsList();
+        emit(DATA_CHANGED);
+        hideBoardsModal();
+      }
+    }
   });
 
   document.getElementById('manage-boards-btn')?.addEventListener('click', showBoardsModal);

--- a/client/src/modules/constants.js
+++ b/client/src/modules/constants.js
@@ -17,3 +17,15 @@ export const DEFAULT_PRIORITY = 'none';
 export const DEFAULT_COLUMN_COLOR = '#3b82f6';
 
 export const MAX_LABEL_NAME_LENGTH = 40;
+
+export const DEFAULT_APP_KEYBINDINGS = {
+  openBoardsModal: { key: 'b', ctrlKey: true, shiftKey: false, altKey: false, metaKey: false }
+};
+
+export function matchesKey(event, binding) {
+  return event.key?.toLowerCase() === binding.key.toLowerCase()
+    && Boolean(event.ctrlKey) === binding.ctrlKey
+    && Boolean(event.shiftKey) === binding.shiftKey
+    && Boolean(event.altKey) === binding.altKey
+    && Boolean(event.metaKey) === binding.metaKey;
+}

--- a/client/src/modules/modals.js
+++ b/client/src/modules/modals.js
@@ -13,7 +13,7 @@ import { showColumnModal, showEditColumnModal, hideColumnModal,
 import { showLabelsModal, hideLabelModal, hideLabelsModal,
   initializeLabelsModalHandlers, setTaskModalState } from './labels-modal.js';
 import { refreshBoardsModalList, hideBoardsModal, hideBoardRenameModal,
-  initializeBoardsModalHandlers } from './boards-modal.js';
+  initializeBoardsModalHandlers, showBoardsModal } from './boards-modal.js';
 
 // ── Shared utility ──────────────────────────────────────────────────
 
@@ -112,6 +112,7 @@ export {
   showEditColumnModal,
   showLabelsModal,
   showHelpModal,
+  showBoardsModal,
   updateTaskLabelsSelection,
   refreshBoardsModalList
 };

--- a/client/src/styles/components/labels.css
+++ b/client/src/styles/components/labels.css
@@ -42,6 +42,11 @@
   background-color: var(--color-primary);
 }
 
+.label-item.keyboard-focused {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
 .label-name {
   flex: 1;
   font-size: 14px;

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -80,6 +80,15 @@
   flex: 0 0 auto;
 }
 
+.brand-text {
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.brand-text:hover {
+  color: var(--color-primary);
+}
+
 .settings-section {
   margin-top: 20px;
   padding-top: 18px;

--- a/client/tests/dom/boards-quick-switch.test.js
+++ b/client/tests/dom/boards-quick-switch.test.js
@@ -94,25 +94,33 @@ describe('click brand-text', () => {
   });
 });
 
-// ── Cycle 2: Shift+B opens boards modal ──────────────────────────────────────
+// ── Cycle 2: Ctrl+B opens boards modal ───────────────────────────────────────
 
-describe('Shift+B shortcut', () => {
+describe('Ctrl+B shortcut', () => {
   it('opens the boards modal', () => {
     const modal = document.getElementById('boards-modal');
 
     expect(modal.classList.contains('hidden')).toBe(true);
-    fireEvent.keyDown(document, { key: 'B', shiftKey: true });
+    fireEvent.keyDown(document, { key: 'B', ctrlKey: true });
     expect(modal.classList.contains('hidden')).toBe(false);
   });
 
-  // ── Cycle 3: Shift+B ignored when input focused ───────────────────────────
+  it('does not open the boards modal with the old Shift+B shortcut', () => {
+    const modal = document.getElementById('boards-modal');
+
+    expect(modal.classList.contains('hidden')).toBe(true);
+    fireEvent.keyDown(document, { key: 'B', shiftKey: true });
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+
+  // ── Cycle 3: Ctrl+B ignored when input focused ────────────────────────────
 
   it('does not open the modal when an input is focused', () => {
     const modal = document.getElementById('boards-modal');
     const input = document.getElementById('board-rename-name');
 
     input.focus();
-    fireEvent.keyDown(document, { key: 'B', shiftKey: true });
+    fireEvent.keyDown(document, { key: 'B', ctrlKey: true });
     expect(modal.classList.contains('hidden')).toBe(true);
   });
 });

--- a/client/tests/dom/boards-quick-switch.test.js
+++ b/client/tests/dom/boards-quick-switch.test.js
@@ -1,0 +1,192 @@
+import { vi, describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { fireEvent } from '@testing-library/dom';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../../src/modules/storage.js', () => ({
+  ensureBoardsInitialized: vi.fn(),
+  listBoards: vi.fn(() => [
+    { id: 'board-1', name: 'Work' },
+    { id: 'board-2', name: 'Personal' },
+  ]),
+  getActiveBoardId: vi.fn(() => 'board-1'),
+  setActiveBoardId: vi.fn(),
+  getActiveBoardName: vi.fn(() => 'Work'),
+  renameBoard: vi.fn(() => true),
+  deleteBoard: vi.fn(() => true),
+}));
+
+vi.mock('../../src/modules/dialog.js', () => ({
+  confirmDialog: vi.fn(async () => false),
+  alertDialog: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../src/modules/icons.js', () => ({
+  renderIcons: vi.fn(),
+}));
+
+vi.mock('../../src/modules/importexport.js', () => ({
+  exportBoard: vi.fn(),
+}));
+
+vi.mock('../../src/modules/events.js', () => ({
+  emit: vi.fn(),
+  DATA_CHANGED: 'data:changed',
+}));
+
+import { initializeBoardsModalHandlers } from '../../src/modules/boards-modal.js';
+import { setActiveBoardId } from '../../src/modules/storage.js';
+import { emit } from '../../src/modules/events.js';
+
+// ── HTML fixture ──────────────────────────────────────────────────────────────
+
+const FIXTURE = `
+  <span id="brand-text" class="brand-text">Work</span>
+  <button id="manage-boards-btn" type="button">Manage Boards</button>
+  <button id="add-board-btn" type="button">Add Board</button>
+  <button id="boards-import-btn" type="button">Import</button>
+  <input id="import-file" type="file">
+  <select id="board-select"></select>
+  <div id="boards-modal" class="hidden">
+    <div class="modal-backdrop"></div>
+    <div id="boards-list"></div>
+    <button id="boards-modal-close-btn" type="button">X</button>
+  </div>
+  <div id="board-rename-modal" class="hidden">
+    <div class="modal-backdrop"></div>
+    <form id="board-rename-form">
+      <h2 id="board-rename-modal-title">Rename Board</h2>
+      <input id="board-rename-name">
+      <button type="submit" id="board-rename-submit-btn">Save</button>
+      <button id="board-rename-cancel-btn" type="button">Cancel</button>
+    </form>
+  </div>
+`;
+
+// Register document-level handlers once. tests/dom/setup.js clears
+// document.body.innerHTML in its own beforeEach, but document-level
+// listeners survive that — so we only register them once here.
+// All handlers in boards-modal.js use event delegation or getElementById
+// at call-time, so they work correctly after the DOM is restored.
+beforeAll(() => {
+  document.body.innerHTML = FIXTURE;
+  initializeBoardsModalHandlers(() => {});
+});
+
+// Restore DOM (setup.js clears it) and reset state before every test.
+beforeEach(() => {
+  document.body.innerHTML = FIXTURE;
+  document.getElementById('boards-modal').classList.add('hidden');
+  document.getElementById('board-rename-modal').classList.add('hidden');
+  vi.clearAllMocks();
+});
+
+// ── Cycle 1: click brand-text opens boards modal ──────────────────────────────
+
+describe('click brand-text', () => {
+  it('opens the boards modal', () => {
+    const brandText = document.getElementById('brand-text');
+    const modal = document.getElementById('boards-modal');
+
+    expect(modal.classList.contains('hidden')).toBe(true);
+    fireEvent.click(brandText);
+    expect(modal.classList.contains('hidden')).toBe(false);
+  });
+});
+
+// ── Cycle 2: Shift+B opens boards modal ──────────────────────────────────────
+
+describe('Shift+B shortcut', () => {
+  it('opens the boards modal', () => {
+    const modal = document.getElementById('boards-modal');
+
+    expect(modal.classList.contains('hidden')).toBe(true);
+    fireEvent.keyDown(document, { key: 'B', shiftKey: true });
+    expect(modal.classList.contains('hidden')).toBe(false);
+  });
+
+  // ── Cycle 3: Shift+B ignored when input focused ───────────────────────────
+
+  it('does not open the modal when an input is focused', () => {
+    const modal = document.getElementById('boards-modal');
+    const input = document.getElementById('board-rename-name');
+
+    input.focus();
+    fireEvent.keyDown(document, { key: 'B', shiftKey: true });
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+});
+
+// ── Cycle 4 & 5: keyboard navigation inside the open boards modal ─────────────
+
+describe('keyboard navigation in open boards modal', () => {
+  it('ArrowDown adds keyboard-focused to the first item on first press', () => {
+    // Open modal first (resets keyboardNavIndex to -1)
+    fireEvent.click(document.getElementById('brand-text'));
+
+    const items = document.querySelectorAll('#boards-list .label-item');
+    expect(items.length).toBe(2);
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    expect(items[0].classList.contains('keyboard-focused')).toBe(true);
+    expect(items[1].classList.contains('keyboard-focused')).toBe(false);
+  });
+
+  it('ArrowDown then ArrowDown moves focus to second item', () => {
+    fireEvent.click(document.getElementById('brand-text'));
+
+    const items = document.querySelectorAll('#boards-list .label-item');
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    expect(items[0].classList.contains('keyboard-focused')).toBe(false);
+    expect(items[1].classList.contains('keyboard-focused')).toBe(true);
+  });
+
+  it('ArrowUp does not go below index 0', () => {
+    fireEvent.click(document.getElementById('brand-text'));
+
+    const items = document.querySelectorAll('#boards-list .label-item');
+    // Start at -1; ArrowUp should stay at 0 (clamps to 0)
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // → 0
+    fireEvent.keyDown(document, { key: 'ArrowUp' });   // → still 0
+
+    expect(items[0].classList.contains('keyboard-focused')).toBe(true);
+  });
+
+  it('does not navigate when modal is closed', () => {
+    // Modal is hidden; ArrowDown should be a no-op
+    const items = document.querySelectorAll('#boards-list .label-item');
+    // Clear any focused class first
+    items.forEach((el) => el.classList.remove('keyboard-focused'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    items.forEach((el) => {
+      expect(el.classList.contains('keyboard-focused')).toBe(false);
+    });
+  });
+
+  // ── Cycle 5: Enter activates the highlighted board ───────────────────────
+
+  it('Enter on highlighted board activates it and closes the modal', () => {
+    fireEvent.click(document.getElementById('brand-text'));
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' }); // index 0 = board-1
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(setActiveBoardId).toHaveBeenCalledWith('board-1');
+    expect(emit).toHaveBeenCalled();
+    expect(document.getElementById('boards-modal').classList.contains('hidden')).toBe(true);
+  });
+
+  it('Enter does nothing when no item is highlighted', () => {
+    fireEvent.click(document.getElementById('brand-text'));
+    // navIndex = -1, no ArrowDown pressed
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(setActiveBoardId).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/unit/constants.test.js
+++ b/client/tests/unit/constants.test.js
@@ -6,7 +6,9 @@ import {
   PRIORITY_ORDER,
   DEFAULT_PRIORITY,
   DEFAULT_COLUMN_COLOR,
-  MAX_LABEL_NAME_LENGTH
+  MAX_LABEL_NAME_LENGTH,
+  DEFAULT_APP_KEYBINDINGS,
+  matchesKey
 } from '../../src/modules/constants.js';
 
 test('PRIORITIES contains 5 values in correct order', () => {
@@ -46,4 +48,11 @@ test('DEFAULT_COLUMN_COLOR is a valid hex color', () => {
 test('MAX_LABEL_NAME_LENGTH is a positive integer', () => {
   expect(Number.isInteger(MAX_LABEL_NAME_LENGTH)).toBe(true);
   expect(MAX_LABEL_NAME_LENGTH).toBeGreaterThan(0);
+});
+
+test('open boards modal shortcut defaults to Ctrl+B', () => {
+  const binding = DEFAULT_APP_KEYBINDINGS.openBoardsModal;
+
+  expect(matchesKey({ key: 'B', ctrlKey: true }, binding)).toBe(true);
+  expect(matchesKey({ key: 'B', shiftKey: true }, binding)).toBe(false);
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   nginx:
     container_name: nginx
-    image: nginx:alpine
+    image: kanvana_nginx:alpine
     build:
       context: .
       dockerfile: devops/local/nginx/Dockerfile

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,7 @@ Want more templates? See [boards.md](boards.md).
 | Document | What you'll find |
 |----------|-----------------|
 | [User Guide (In-App Help)](help-how-to.md) | The canonical help text shown inside the app |
+| [Keyboard Shortcuts](user/keybindings.md) | Current keyboard shortcuts and where each one works |
 | [Board Templates](boards.md) | Templates you can import + best practices for columns and workflows |
 | [Labels Guide](labels.md) | How to use labels and groups for filtering and categorization |
 | [Specification Index](specification-kanban.md) | Canonical spec entrypoint, governance, and links to all feature/data spec files |
@@ -83,8 +84,9 @@ Want more templates? See [boards.md](boards.md).
 New to Kanban? Here's where to start:
 
 1. **[User Guide (In-App Help)](help-how-to.md)** — Learn the UI quickly: boards, tasks, columns, labels, import/export
-2. **[Board Templates](boards.md)** — Pick a workflow and import a ready-to-use board
-3. **[Labels Guide](labels.md)** — Build a label system that helps you filter without turning labels into “status”
+2. **[Keyboard Shortcuts](user/keybindings.md)** — Move faster with board, modal, task, and notification shortcuts
+3. **[Board Templates](boards.md)** — Pick a workflow and import a ready-to-use board
+4. **[Labels Guide](labels.md)** — Build a label system that helps you filter without turning labels into “status”
 
 ---
 

--- a/docs/system/spec/board-ui.md
+++ b/docs/system/spec/board-ui.md
@@ -19,6 +19,7 @@
 
 - Board selection persists and restores on page load
 - Manage Boards supports create, open, export, import, rename, and delete actions
+- Clicking the brand text or pressing `Ctrl+B` opens the Manage Boards modal; the shortcut is ignored while focus is in an input, textarea, or select
 - New boards can be blank or created from a template
 - Built-in templates may preload workflow-specific starter columns, grouped labels, and labeled tasks so a new board is immediately usable
 - The last remaining board cannot be deleted

--- a/docs/user/help-how-to.md
+++ b/docs/user/help-how-to.md
@@ -101,6 +101,8 @@ Important notes:
 
 ### Keyboard & Modal Shortcuts
 
+- See [Keyboard Shortcuts](keybindings.md) for the full current shortcut table.
+- **Ctrl+B** opens Manage Boards unless you are typing in a form field.
 - **Escape** closes most modals.
 - Clicking the **backdrop** closes most modals.
 
@@ -123,5 +125,4 @@ Short, action-oriented titles are easiest to execute. Examples:
 - Investigate
 
 ---
-
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -1,0 +1,21 @@
+# Keyboard Shortcuts
+
+Kanvana supports keyboard shortcuts for fast board management, modal handling, task editing, and accessible list activation. Global shortcuts avoid form fields so typing in inputs, textareas, and selects does not trigger board actions.
+
+| Area | Key binding | Action | Notes |
+|---|---|---|---|
+| Global board navigation | `Ctrl+B` | Open the Manage Boards modal | Ignored while focus is in an input, textarea, or select |
+| Global modal handling | `Escape` | Close the active modal, dialog, or column menu | Applies to task, column, labels, board, help, login, settings, notifications, confirmation dialogs, and open column menus |
+| Manage Boards modal | `ArrowDown` | Move focus to the next board | Works only while the Manage Boards modal is open |
+| Manage Boards modal | `ArrowUp` | Move focus to the previous board | Works only while the Manage Boards modal is open |
+| Manage Boards modal | `Enter` | Open the highlighted board | Closes the Manage Boards modal after switching |
+| Task label search | `ArrowDown` | Move highlight to the next label result | Works in the task editor label search field |
+| Task label search | `ArrowUp` | Move highlight to the previous label result | Works in the task editor label search field |
+| Task label search | `Enter` | Toggle the highlighted label or open Add Label for a new label | Clears the label search after toggling an existing label |
+| Sub-task quick add | `Enter` | Add the typed sub-task | Works in the task editor sub-task input |
+| Inline sub-task edit | `Enter` | Save the edited sub-task title | Works while editing a sub-task title inline |
+| Inline sub-task edit | `Escape` | Cancel the inline sub-task edit | Restores the previous title |
+| Notifications banner | `Enter` or `Space` | Open the focused notification task | Works on keyboard-focused notification items |
+| Notifications banner | `Enter` or `Space` | Open the notifications modal from the focused overflow item | Applies to the `+N` overflow item |
+| Notifications modal | `Enter` or `Space` | Open the focused task and close the notifications modal | Works on keyboard-focused notification rows |
+


### PR DESCRIPTION
This pull request introduces a new "Quick Board Switch" feature, making it much faster and easier to switch between boards via both mouse and keyboard. Users can now open the Manage Boards modal by clicking the board name in the header or using the new `Ctrl+B` keyboard shortcut (which is form-safe). The modal now supports full keyboard navigation, including cycling through boards with arrow keys and activating with `Enter`. The changes also include user-facing documentation for keyboard shortcuts, improved accessibility and visual feedback, and comprehensive tests for the new interactions.

**Quick Board Switch & Keyboard Navigation:**

* Clicking the board name (`#brand-text`) in the header now opens the Manage Boards modal; the element is now a button with appropriate ARIA roles and a tooltip. (`client/src/index.html`, `client/src/styles/layout.css`, `README.md`, `CHANGELOG.md`, `docs/system/spec/board-ui.md`) [[1]](diffhunk://#diff-e13bb9ab1347edb6e8fdafe64e5e05102c588e201f6c9da7c94c14caeb0bc2fbL22-R22) [[2]](diffhunk://#diff-056ad4dc3d0bcb94b316f13e612d5e00eaafdd5f2694e970772b6e1306edea6cR83-R91) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R87) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28) [[5]](diffhunk://#diff-0026ba062abc7d97eeb8ca69956388d35b162965089a50d4864d0d28cbcdcfabR22)
* Added a global `Ctrl+B` keyboard shortcut to open the Manage Boards modal, ignored when focus is in an input, textarea, or select. (`client/src/modules/constants.js`, `client/src/modules/boards-modal.js`, `CHANGELOG.md`, `README.md`, `docs/readme.md`) [[1]](diffhunk://#diff-d56e46fb1412c85298f0eaf92b84a828a896ac4bdaf2ae5c95442b0b34668eebR20-R31) [[2]](diffhunk://#diff-23c6046b6596480bd6d0b09ba0bfc9136a2eec0d2bac60faa1f9b74778dfeab0R16-R19) [[3]](diffhunk://#diff-23c6046b6596480bd6d0b09ba0bfc9136a2eec0d2bac60faa1f9b74778dfeab0R201-R250) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R87) [[6]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34R74) [[7]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34L86-R89)
* The Manage Boards modal now supports keyboard navigation: arrow keys cycle through boards, and `Enter` activates the highlighted board and closes the modal. Visual focus is indicated for accessibility. (`client/src/modules/boards-modal.js`, `client/src/styles/components/labels.css`, `CHANGELOG.md`) [[1]](diffhunk://#diff-23c6046b6596480bd6d0b09ba0bfc9136a2eec0d2bac60faa1f9b74778dfeab0L143-R164) [[2]](diffhunk://#diff-3a8ac9296761e1c57bae505beafa8ff2242b55b7bb24aa4bf9aaa98a7a33310dR45-R49) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28)

**Codebase & Testing Improvements:**

* Exported `showBoardsModal` from `boards-modal.js` and re-exported via `modals.js` for easier integration and testing. (`client/src/modules/boards-modal.js`, `client/src/modules/modals.js`, `CHANGELOG.md`) [[1]](diffhunk://#diff-23c6046b6596480bd6d0b09ba0bfc9136a2eec0d2bac60faa1f9b74778dfeab0L143-R164) [[2]](diffhunk://#diff-b1e5fecabf52db2912c27cad4bf157f897e7fd9d1f6a770b41fcee3f67ede950L16-R16) [[3]](diffhunk://#diff-b1e5fecabf52db2912c27cad4bf157f897e7fd9d1f6a770b41fcee3f67ede950R115) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28)
* Added comprehensive DOM and unit tests for the new board switching and keyboard navigation functionality, including edge cases. (`client/tests/dom/boards-quick-switch.test.js`, `client/tests/unit/constants.test.js`) [[1]](diffhunk://#diff-ef1f8006dbc1b2bedb756ab581292359b06275148c340a5f56807580c35b998bR1-R200) [[2]](diffhunk://#diff-50da01537c67b4bb21b77963f7fe6ae03f3d6edc41764d8d800701f4641f89fcL9-R11) [[3]](diffhunk://#diff-50da01537c67b4bb21b77963f7fe6ae03f3d6edc41764d8d800701f4641f89fcR52-R58)

**Documentation & Config:**

* Added a user-facing keyboard shortcuts table in `docs/user/keybindings.md` and linked it from the main documentation. (`README.md`, `docs/readme.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R87) [[2]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34R74) [[3]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34L86-R89) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28)
* Updated the changelog and documentation to reflect the new features and shortcut. (`CHANGELOG.md`, `README.md`, `docs/readme.md`, `docs/system/spec/board-ui.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL31-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R87) [[4]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34R74) [[5]](diffhunk://#diff-311fffb2f63c2d97ead8bee2b1b6ea35591871552bc00d572c3670212b043a34L86-R89) [[6]](diffhunk://#diff-0026ba062abc7d97eeb8ca69956388d35b162965089a50d4864d0d28cbcdcfabR22)

**Other minor changes:**

* Added the production PocketBase URL as a secret in the CI workflow and updated the Docker Compose config for the nginx image. (`.github/workflows/ci.yml`, `docker-compose.yml`, `CHANGELOG.md`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR72-R73) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-R4) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R28)