### PR TITLE
fix: update build context in backend.yml for Docker build

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./backend
+          context: .
           file: ./backend/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true


### PR DESCRIPTION
This pull request makes a minor update to the Docker build configuration in the backend workflow. The build context is changed from the `./backend` directory to the project root, which may be necessary if files outside `./backend` are needed during the Docker build process.

* Changed the Docker build context in `.github/workflows/backend.yml` from `./backend` to `.` to include the entire project in the Docker build.
